### PR TITLE
Add container logging params

### DIFF
--- a/.data/telco/clickhouse/config.d/config.xml
+++ b/.data/telco/clickhouse/config.d/config.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <logger>
+        <level>warning</level>
+        <log>/dev/null</log>
+    </logger>
+</clickhouse>

--- a/.data/telco/clickhouse/config.d/config.xml
+++ b/.data/telco/clickhouse/config.d/config.xml
@@ -3,4 +3,14 @@
         <level>warning</level>
         <log>/dev/null</log>
     </logger>
+
+    <profiles>
+        <default>
+            <log_queries>0</log_queries>
+            <log_processors_profiles>0</log_processors_profiles>
+            <log_profile_events>0</log_profile_events>
+            <log_query_settings>0</log_query_settings>
+            <log_query_views>0</log_query_views>
+        </default>
+    </profiles>
 </clickhouse>


### PR DESCRIPTION
```
VOLUME NAME                                                        LINKS     SIZE
axiomdata_postgres-data                                            1         81.14MB
dc9f18ab2f3825d591aafa2acee5a29fc2ed77ec58ed4264999eeb7be54e476d   1         0B
898c04e8e2d7c30a190355523b56fb26b035ab65ad26a7d8c879bf49c31da6df   1         88B
axiomdata_clickhouse_data                                          1         11.24GB
axiomdata_mongodb-data                                             1         425.1MB
axiomdata_pgvector-data                                            1         43.65MB
```

Who could the culprit be???


```

    ┌─table──────────────────────────────────────────┬─formatReadableSize(sum(bytes))─┐
 1. │ trace_log_2                                    │ 3.85 GiB                       │
 2. │ trace_log_1                                    │ 2.48 GiB                       │
 3. │ text_log_0                                     │ 1.74 GiB                       │
 4. │ text_log                                       │ 1.26 GiB                       │
 5. │ metric_log_0                                   │ 309.90 MiB                     │
 6. │ metric_log                                     │ 217.25 MiB                     │
 7. │ asynchronous_metric_log_0                      │ 124.80 MiB                     │
 8. │ asynchronous_metric_log                        │ 87.97 MiB                      │
 9. │ trace_log_0                                    │ 13.80 MiB                      │
10. │ error_log                                      │ 9.42 MiB                       │
11. │ processors_profile_log_0                       │ 7.58 MiB                       │
12. │ processors_profile_log                         │ 6.68 MiB                       │
13. │ query_log_0                                    │ 4.64 MiB                       │
14. │ trace_log                                      │ 2.67 MiB                       │
15. │ query_log                                      │ 2.02 MiB                       │
16. │ network_performance                            │ 1.73 MiB                       │
17. │ cdr                                            │ 1.19 MiB                       │
18. │ .inner_id.31f7f91d-2c78-49fa-b72b-8357be98d66a │ 1.18 MiB                       │
19. │ data_usage                                     │ 1.04 MiB                       │
20. │ query_metric_log                               │ 447.78 KiB                     │
21. │ error_log_0                                    │ 415.44 KiB                     │
22. │ query_metric_log_0                             │ 110.89 KiB                     │
23. │ part_log                                       │ 4.06 KiB                       │
24. │ query_views_log                                │ 3.48 KiB                       │
    └────────────────────────────────────────────────┴────────────────────────────────┘

24 rows in set. Elapsed: 0.407 sec.
```