### PR TITLE
Allow CICD to use DEBUG output

### DIFF
--- a/.github/workflows/ddn-deploy.yaml
+++ b/.github/workflows/ddn-deploy.yaml
@@ -79,9 +79,9 @@ jobs:
               --override-description "$description" \
               --rebuild-connectors \
               --override \
-              --log-level FATAL \
-              --quiet \
-              --no-interaction > build_output.json
+              --log-level DEBUG \
+              --json-output $RUNNER_TEMP/axiom.json \
+              --no-interaction
           else
             echo "Skipping connector build."
             ./scripts/deploy/deploy.mjs \
@@ -89,17 +89,17 @@ jobs:
               --profile telco \
               --override-description "$description" \
               --override \
-              --log-level FATAL \
-              --quiet \
-              --no-interaction > build_output.json
+              --log-level DEBUG \
+              --json-output $RUNNER_TEMP/axiom.json \
+              --no-interaction
           fi
 
       - name: Extract URLs from JSON
         if: env.no_op != 'true'
         run: |
-          cat build_output.json
-          BUILD_URLS=$(jq -r '.build_url' build_output.json | tr '\n' ',')
-          CONSOLE_URLS=$(jq -r '.console_url' build_output.json | tr '\n' ',')
+          cat $RUNNER_TEMP/axiom.json
+          BUILD_URLS=$(jq -r '.build_url' $RUNNER_TEMP/axiom.json | tr '\n' ',')
+          CONSOLE_URLS=$(jq -r '.console_url' $RUNNER_TEMP/axiom.json | tr '\n' ',')
           echo "build_urls=${BUILD_URLS%,}" >> $GITHUB_ENV
           echo "console_urls=${CONSOLE_URLS%,}" >> $GITHUB_ENV
 

--- a/scripts/deploy/deploy.mjs
+++ b/scripts/deploy/deploy.mjs
@@ -30,6 +30,7 @@ class DeploymentManager {
             .option('-x, --override-description <desc>', 'Override description')
             .option('-q, --quiet', 'Quiet mode')
             .option('-a, --apply-build', 'Auto-apply build', false)
+            .option('-j, --json-output <file>', 'Output build info to JSON file')
             .parse(process.argv);
 
         const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -85,6 +86,13 @@ class DeploymentManager {
             const output = await this.execCommand(cmd, context);
             const buildInfo = JSON.parse(output);
             this.options.quiet && console.log(output);
+            if (this.options.jsonOutput) {
+                try {
+                    fs.writeFileSync(this.options.jsonOutput, output);
+                } catch (err) {
+                    console.error(`Failed to write to JSON output file: ${err.message}`);
+                }
+            }
             return buildInfo;
         }
     }


### PR DESCRIPTION
A lot of the CICD errors were previously hidden behind FATAL which was put in place to allow automatic applications. This should resolve that